### PR TITLE
Clear selects before loading (fixes Cancel)

### DIFF
--- a/web-ng/root/js/admin/components/AdminInfoUpdateComponent.js
+++ b/web-ng/root/js/admin/components/AdminInfoUpdateComponent.js
@@ -194,7 +194,7 @@ AdminInfoUpdateComponent._saveError = function( topic, message ) {
 
 AdminInfoUpdateComponent._cancel = function() {
     Dispatcher.publish(AdminInfoUpdateComponent.formCancelTopic);
-    Dispatcher.publish(AdminInfoUpdateComponent.info_topic);
+    Dispatcher.publish(AdminInfoUpdateComponent.metadataTopic);
 
 };
 

--- a/web-ng/root/js/admin/components/CommunityUpdateComponent.js
+++ b/web-ng/root/js/admin/components/CommunityUpdateComponent.js
@@ -86,7 +86,7 @@ CommunityUpdateComponent._selectCommunities = function() {
     var sel = $('#update_communities');
     var host = CommunityUpdateComponent.communities.host;
    
-    sel.empty();
+    sel.empty(); // remove old options, if any
 
     CommunityUpdateComponent._combineCommunities();
 

--- a/web-ng/root/js/admin/components/HostMetadataComponent.js
+++ b/web-ng/root/js/admin/components/HostMetadataComponent.js
@@ -24,6 +24,7 @@ HostMetadataComponent._setMetadata = function( topic ) {
     var roleValues = SharedUIFunctions.getSelectedValues( allRoles, selectedRoles );  
     
     var roleSel = $('#node_role_select');
+    roleSel.empty();
     roleSel.select2( { 
         placeholder: HostMetadataComponent.rolePlaceholder,
         data: roleValues,
@@ -35,6 +36,7 @@ HostMetadataComponent._setMetadata = function( topic ) {
     var accessPolicyValues = SharedUIFunctions.getSelectedValues( allAccessPolicies, selectedAccessPolicies );
 
     var accessPolicySel = $('#access_policy');
+    accessPolicySel.empty();
     accessPolicySel.select2( { 
         placeholder: HostMetadataComponent.policyPlaceholder,
         data: accessPolicyValues,


### PR DESCRIPTION
Fixed an issue where selectors on the admin info page weren't being
cleared when the user clicked Cancel. Fixes #92.