### PR TITLE
Update config_daemon config to restart ntp

### DIFF
--- a/etc/configdaemon.conf
+++ b/etc/configdaemon.conf
@@ -54,6 +54,8 @@ firewall_script /usr/lib/perfsonar/scripts/system_environment/configure_firewall
 		stop		1
 	</service>
 	<service ntp>
+		start		1
+		stop		1
 		restart		1
 	</service>
 	<file "/etc/ntp.conf">

--- a/etc/configdaemon.conf
+++ b/etc/configdaemon.conf
@@ -53,6 +53,9 @@ firewall_script /usr/lib/perfsonar/scripts/system_environment/configure_firewall
 		start		1
 		stop		1
 	</service>
+	<service ntp>
+		restart		1
+	</service>
 	<file "/etc/ntp.conf">
 		read	1
 		write	1


### PR DESCRIPTION
I updated configdaemon.conf to allow restarting ntp, but did not set it to start/stop it. This might need some adjustment. See #99