### PR TITLE
Intf aliases toolkit

### DIFF
--- a/web-ng/root/js/admin/components/TestConfigComponent.js
+++ b/web-ng/root/js/admin/components/TestConfigComponent.js
@@ -57,8 +57,9 @@ TestConfigComponent.initialize = function() {
         return ret;
     });
 
-    Handlebars.registerHelper('hostname_or_ip', function(hostnames, ipv4_addresses, ipv6_addresses, options) {
-    // For one interface, which may have multiple ip's (and each ip may have multiple hostnames),
+    Handlebars.registerHelper('hostname_or_ip', function(ifname, hostnames, ipv4_addresses, ipv6_addresses, options) {
+    // Get all the hostnames (or ip's if no reverse DNS) for an interface. 
+    // (Each interface may have multiple ip's and each ip may have multiple hostnames)
     // hostnames[ip] = array of hostnames for that ip,  ipv4/6_addresses = array of all v4/v6 ip's. 
         var ret = [];
         for(var a=0; a<ipv4_addresses.length; a+=1) {
@@ -80,7 +81,14 @@ TestConfigComponent.initialize = function() {
             return arr.indexOf(el) === i;
         });
 
-        return deduped.join(", ");
+        var hostnames_string = deduped.join(", ");
+
+        // look for loopbacks and add a note about them
+        if ( ifname == "lo" || ifname.startsWith("lo:") ) {
+            hostnames_string += "  [note: loopbacks are not normally used in tests]";
+        }    
+
+        return hostnames_string;
     });
 
     // Hide subrows on load

--- a/web-ng/root/js/admin/components/TestConfigComponent.js
+++ b/web-ng/root/js/admin/components/TestConfigComponent.js
@@ -58,22 +58,29 @@ TestConfigComponent.initialize = function() {
     });
 
     Handlebars.registerHelper('hostname_or_ip', function(hostnames, ipv4_addresses, ipv6_addresses, options) {
+    // For one interface, which may have multiple ip's (and each ip may have multiple hostnames),
+    // hostnames[ip] = array of hostnames for that ip,  ipv4/6_addresses = array of all v4/v6 ip's. 
         var ret = [];
         for(var a=0; a<ipv4_addresses.length; a+=1) {
-            if (typeof hostnames != "undefined" && hostnames[ipv4_addresses[a]]) {
-                ret = ret.concat(hostnames[ipv4_addresses[a]]);
+            if (typeof hostnames != "undefined" && hostnames[ipv4_addresses[a]].length>0) {
+                ret = ret.concat(hostnames[ipv4_addresses[a]]); // join ret and array of hostnames
             } else {
-                ret.push(ipv4_addresses[a]);
+                ret.push(ipv4_addresses[a]); // append ip
             }
         }
         for(var a=0; a<ipv6_addresses.length; a+=1) {
-            if (typeof hostnames != "undefined" && hostnames[ipv6_addresses[a]]) {
+            if (typeof hostnames != "undefined" && hostnames[ipv6_addresses[a]].length>0) {
                 ret = ret.concat(hostnames[ipv6_addresses[a]]);
             } else {
                 ret.push(ipv6_addresses[a]);
             }
         }
-        return ret.join(", ");
+        // this removes duplicate hostnames and ip's
+        var deduped = ret.filter( function (el, i, arr) {
+            return arr.indexOf(el) === i;
+        });
+
+        return deduped.join(", ");
     });
 
     // Hide subrows on load

--- a/web-ng/templates/admin/components/configure_test.html
+++ b/web-ng/templates/admin/components/configure_test.html
@@ -89,7 +89,7 @@
                         <select id="interfaceSelector">
                             <option value="" {{#unless parameters.local_interface}}selected{{/unless}}>Default</option>
                         {{#each interfaces}}
-                            <option value="{{iface}}" {{#compare iface ../parameters.local_interface}}selected{{/compare}}>{{iface}} - {{hostname_or_ip hostnames ipv4_address ipv6_address}}</option>
+                            <option value="{{iface}}" {{#compare iface ../parameters.local_interface}}selected{{/compare}}>{{iface}} - {{hostname_or_ip iface hostnames ipv4_address ipv6_address}}</option>
                         {{/each}}
                          </select>
                     </div>


### PR DESCRIPTION
intf_aliases_toolkit and intf_aliases_shared branches have changes needed to include loopbacks and aliases in the list of interfaces when configuring a test.
Interface lists now include loopbacks and aliases, with up and unknown states, global- and host-scope addresses.
Also fixed detection of ipv6 addresses and removed duplicate hostnames (or ip's) from the descriptions following the interface names in the selector. 