### PR TITLE
manage_users: add missing quote to grep regex

### DIFF
--- a/scripts/manage_users
+++ b/scripts/manage_users
@@ -127,7 +127,7 @@ def password(user=None):
         user_exists = True
 
         if htpasswd_exists:
-            retVal = os.system("grep -q '^" + user + ": " + htpasswd_file)
+            retVal = os.system("grep -q '^" + user + ":' " + htpasswd_file)
             if int(retVal) != 0:
                 user_exists = False
         else:


### PR DESCRIPTION
Fixes option ``3. Change a user's password`` in ``manage_users``.