### PR TITLE
Update host status to display reference ID from ntpq

### DIFF
--- a/web-ng/templates/host/sidebar_host_status.html
+++ b/web-ng/templates/host/sidebar_host_status.html
@@ -218,6 +218,18 @@
                 <span class="sidebar-popover__value">{{stratum}}</span>
             </li>
             {{/if}}
+            {{#if type}}
+            <li class="sidebar-popover__item">
+                <span class="sidebar-popover__param">Type:</span>
+                <span class="sidebar-popover__value">{{type}}</span>
+            </li>
+            {{/if}}
+            {{#if when}}
+            <li class="sidebar-popover__item">
+                <span class="sidebar-popover__param">When:</span>
+                <span class="sidebar-popover__value">{{when}}</span>
+            </li>
+            {{/if}}
             {{#if reach}}
             <li class="sidebar-popover__item">
                 <span class="sidebar-popover__param">Reach:</span>

--- a/web-ng/templates/host/sidebar_host_status.html
+++ b/web-ng/templates/host/sidebar_host_status.html
@@ -206,10 +206,10 @@
                 <span class="sidebar-popover__value">{{host}}</span>
             </li>
             {{/if}}
-            {{#if address}}
+            {{#if refid}}
             <li class="sidebar-popover__item">
-                <span class="sidebar-popover__param">Address:</span>
-                <span class="sidebar-popover__value">{{address}}</span>
+                <span class="sidebar-popover__param">Reference ID:</span>
+                <span class="sidebar-popover__value">{{refid}}</span>
             </li>
             {{/if}}
             {{#if stratum}}


### PR DESCRIPTION
Local address field in ``ntpdc`` is replaced by reference ID in ``ntpq``:
```
$ ntpdc -p
     remote           local      st poll reach  delay   offset    disp
=======================================================================
=zg2.ntp.CARNet. 2001:b68:ff:1::  2 1024  377 0.00073 -0.000021 0.13818
=tack.Informatik 161.53.160.238  16 1024    0 0.00000  0.000000 3.99217
*zg1.ntp.CARNet. 161.53.160.238   2 1024  377 0.00041  0.000011 0.13770
```
```
$ ntpq -p
     remote           refid      st t when poll reach   delay   offset  jitter
==============================================================================
*zg1.ntp.CARNet. 161.53.123.8     2 u  117 1024  377    0.417    0.011   0.058
+zg2.ntp.CARNet. 161.53.123.8     2 u  399 1024  377    0.736   -0.021   0.049
 tack.Informatik .STEP.          16 u    - 1024    0    0.000    0.000   0.000
```