### PR TITLE
Fix UTF8 failure in unit tests

### DIFF
--- a/t/host-update_metadata.t
+++ b/t/host-update_metadata.t
@@ -18,6 +18,7 @@ Log::Log4perl->easy_init( {level => 'OFF'} );
 
 use Test::More tests => 23;
 
+use utf8;
 use Config::General;
 use Data::Dumper;
 use Test::MockObject::Extends;


### PR DESCRIPTION
```
  #   Failed test 'Metadata values are as expected ( save_success: 1; restart_success: 0 )'
  #   at /tmp/buildd/perfsonar-toolkit-4.0.1+20170824200812/t/lib/perfSONAR_PS/NPToolkit/UnitTests/Util.pm line 121.
  # Compared $data->{"location"}{"city"}
  #    got : 'Bogat�
  # expect : 'Bogatá'

  #   Failed test 'Metadata values are as expected ( save_success: 1; restart_success: -1 )'
  #   at /tmp/buildd/perfsonar-toolkit-4.0.1+20170824200812/t/lib/perfSONAR_PS/NPToolkit/UnitTests/Util.pm line 121.
  # Compared $data->{"location"}{"city"}
  #    got : 'Bogat�
  # expect : 'Bogatá'
  # Looks like you failed 2 tests of 23.
  t/host-update_metadata.t ....
  Dubious, test returned 2 (wstat 512, 0x200)
  Failed 2/23 subtests
```