### PR TITLE
Fix utf8 warning in apache error log

### DIFF
--- a/web-ng/root/admin/services/regular_testing.cgi
+++ b/web-ng/root/admin/services/regular_testing.cgi
@@ -45,7 +45,7 @@ if ( $conf{logger_conf} ) {
 else {
 
     # If they've not specified a logger, send it all to /dev/null
-    Log::Log4perl->easy_init( { level => $DEBUG, file => "/dev/null" } );
+    Log::Log4perl->easy_init( { level => $DEBUG, file => "/dev/null", utf8 => 1 } );
 }
 
 our $logger = get_logger( "perfSONAR_PS::WebGUI::ServiceStatus" );


### PR DESCRIPTION
[Wed Aug 30 06:11:41 2017] regular_testing.cgi: Wide character in print at /usr/share/perl5/vendor_perl/Log/Log4perl/Appender/File.pm line 245., referer: https://192.168.122.173/toolkit/auth/admin/tests.cgi