### PR TITLE
Adding default rules for pScheduler tool data ports. We previously go…

### DIFF
--- a/etc/perfsonar_firewall_settings.conf
+++ b/etc/perfsonar_firewall_settings.conf
@@ -22,6 +22,28 @@
 # UDP Traceroute (Incoming)
 -A perfSONAR -m udp -p udp --dport 33434:33634 -j ACCEPT
 
+# iperf3 (TCP)
+-A perfSONAR -m state --state NEW -m tcp -p tcp --dport 5201 -j ACCEPT
+
+# iperf3 (UDP)
+-A perfSONAR -m udp -p udp --dport 5201 -j ACCEPT
+
+# iperf2 (TCP)
+-A perfSONAR -m state --state NEW -m tcp -p tcp --dport 5001 -j ACCEPT
+
+# iperf2 (UDP)
+-A perfSONAR -m udp -p udp --dport 5001 -j ACCEPT
+
+# nuttcp (TCP)
+-A perfSONAR -m state --state NEW -m tcp -p tcp --dport 5000 -j ACCEPT
+-A perfSONAR -m state --state NEW -m tcp -p tcp --dport 5101 -j ACCEPT
+
+# nuttcp (UDP)
+-A perfSONAR -m udp -p udp --dport 5000 -j ACCEPT
+-A perfSONAR -m udp -p udp --dport 5101 -j ACCEPT
+
+# simplestream (TCP)
+-A perfSONAR -m state --state NEW -m tcp -p tcp --dport 5890-5900 -j ACCEPT
 
 # =-=-=-=-=-=- perfSONAR Measurement Tools: control =-=-=-=-=-=-
 

--- a/etc/perfsonar_firewalld_settings.conf
+++ b/etc/perfsonar_firewalld_settings.conf
@@ -15,6 +15,28 @@
 # UDP Traceroute (Incoming)
 --add-service=traceroute
 
+# iperf3 (TCP)
+--add-port=5201/tcp
+
+# iperf3 (UDP)
+--add-port=5201/udp
+
+# iperf2 (TCP)
+--add-port=5001/tcp
+
+# iperf2 (UDP)
+--add-port=5001/udp
+
+# nuttcp (TCP)
+--add-port=5000/tcp
+--add-port=5101/tcp
+
+# nuttcp (UDP)
+--add-port=5000/udp
+--add-port=5101/udp
+
+# simplestream (TCP)
+--add-port=5890-5900/tcp
 
 # =-=-=-=-=-=- perfSONAR Measurement Tools: control =-=-=-=-=-=-
 
@@ -26,7 +48,6 @@
 
 # TWAMP Control (Incoming)
 --add-service=twamp-control
-
 
 # =-=-=-=-=-=- Core perfSONAR Services =-=-=-=-=-=-
 


### PR DESCRIPTION
Fixes firewall rules when BWCTL is not installed.