### PR TITLE
Use RewriteEngine to disable OPTIONS method

### DIFF
--- a/etc/apache-perfsonar-security.conf
+++ b/etc/apache-perfsonar-security.conf
@@ -8,11 +8,9 @@ SSLCipherSuite ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-E
 TraceEnable      Off
 
 #disable HTTP OPTIONS method
-<Location />
-    <Limit OPTIONS>
-        Require all denied
-    </Limit>
-</Location>
+RewriteEngine On
+RewriteCond %{REQUEST_METHOD} ^OPTIONS
+RewriteRule .* - [F]
 
 #disable printing of server tokens
 ServerTokens Prod


### PR DESCRIPTION
Require interferes with the authentication for /maddash-webui/admin allowing admin access without login.