### PR TITLE
contradicting limits in the application

### DIFF
--- a/etc/default_service_configs/pscheduler_limits.conf
+++ b/etc/default_service_configs/pscheduler_limits.conf
@@ -235,9 +235,8 @@
 	    "classifier": "default",
 	    "apply": [
 		{
-		    "require": "any",
+		    "require": "all",
 		    "limits": [
-			"innocuous-tests",
                         "throughput-default-time",
                         "throughput-default-udp",
 			"idleex-default"

--- a/etc/default_service_configs/pscheduler_limits.conf
+++ b/etc/default_service_configs/pscheduler_limits.conf
@@ -235,7 +235,7 @@
 	    "classifier": "default",
 	    "apply": [
 		{
-		    "require": "all",
+		    "require": "any",
 		    "limits": [
 			"innocuous-tests",
                         "throughput-default-time",


### PR DESCRIPTION
Require "all" application with contradicting limits leads to guaranteed failures