### PR TITLE
Fix the archive URL for Debian builds

### DIFF
--- a/toolkit/perfsonar-toolkit/unibuild-packaging/deb/perfsonar-toolkit-archive-utils.postinst
+++ b/toolkit/perfsonar-toolkit/unibuild-packaging/deb/perfsonar-toolkit-archive-utils.postinst
@@ -23,7 +23,7 @@ case "$1" in
         # Configure http archiver
         if [ -f /etc/perfsonar/logstash/proxy_auth.json ] ; then
             AUTH_HEADER=`cat /etc/perfsonar/logstash/proxy_auth.json`
-            sed -i "s|:11283|/logstash|g" /etc/perfsonar/psconfig/archives.d/http_logstash.json
+            sed -i "s|http://localhost:11283|https://{% scheduled_by_address %}/logstash|g" /etc/perfsonar/psconfig/archives.d/http_logstash.json
             sed -i "s|\"content-type\": \"application/json\"|\"content-type\": \"application/json\", ${AUTH_HEADER}|g" /etc/perfsonar/psconfig/archives.d/http_logstash.json
         fi
     ;;


### PR DESCRIPTION
Fixes #75

The archive url should be the hostname of the node that schedules the test. Update the sed re-write two match the same as on RPM builds using the template parameter {% scheduled_by_address %} and the public /logstash path rather than the default localhost and port.