### PR TITLE
Removed the conflict on Network Manager

### DIFF
--- a/toolkit/perfsonar-toolkit/unibuild-packaging/deb/control
+++ b/toolkit/perfsonar-toolkit/unibuild-packaging/deb/control
@@ -54,12 +54,10 @@ Description: perfSONAR Toolkit firewall configuration
 Package: perfsonar-toolkit-sysctl
 Architecture: all
 Depends: libperfsonar-perl, ${perl:Depends}, ${misc:Depends}
-Conflicts: network-manager
 Description: perfSONAR Toolkit sysctl configuration
  Configures sysctl settings for perfSONAR Toolkit.
  These settings are tuning the network stack.
- Conflicts with network-manager.
-
+ 
 Package: perfsonar-toolkit-ntp
 Architecture: all
 Depends: time-daemon, perfsonar-toolkit-library,


### PR DESCRIPTION
 I tested it on Ubuntu 24 that perfsonar toolkit works with Network Manager Service so I removed the conflict line on Network Manager from 'control' file